### PR TITLE
Add Core Edge static site

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -1,1 +1,12 @@
-TBD
+Core Edge Website
+=================
+
+This repository contains a simple static website for **Core Edge**, a company delivering automated software to ensure SAP custom objects are compliant with S/4HANA and clean-core standards.
+
+The site provides:
+
+- Overview of free system analysis and paid remediation.
+- Login area (front-end only) and multilingual support (English, German, Spanish).
+- FAQ and contact form.
+
+Open-source Feather icons are used under the MIT license.

--- a/website/css/styles.css
+++ b/website/css/styles.css
@@ -1,0 +1,106 @@
+body {
+    font-family: 'Roboto', sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    color: #333;
+}
+
+header {
+    background: #0b2239;
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+}
+
+header .logo {
+    height: 40px;
+    display: block;
+}
+header ul {
+    list-style: none;
+    display: flex;
+    margin: 0;
+    padding: 0;
+}
+
+header li {
+    margin-right: 1rem;
+}
+
+header a {
+    color: #fff;
+    text-decoration: none;
+}
+
+#lang-select {
+    margin-left: 1rem;
+}
+
+.hero {
+    background: linear-gradient(135deg, #2980b9, #6dd5fa);
+    color: #fff;
+    padding: 5rem 2rem;
+    text-align: center;
+}
+
+.features {
+    display: flex;
+    justify-content: space-around;
+    padding: 2rem;
+    flex-wrap: wrap;
+}
+
+.feature {
+    flex: 1 1 200px;
+    margin: 1rem;
+    text-align: center;
+}
+
+.feature i {
+    color: #2980b9;
+    width: 48px;
+    height: 48px;
+}
+
+.login, .faq, .contact {
+    padding: 2rem;
+    max-width: 800px;
+    margin: auto;
+}
+
+.login form, .contact form {
+    display: flex;
+    flex-direction: column;
+}
+
+.login input, .contact input, .contact textarea {
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    background: #2980b9;
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+footer {
+    background: #0b2239;
+    color: #fff;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 2rem;
+}
+
+.note {
+    font-size: 0.9rem;
+    color: #777;
+}

--- a/website/images/logo.svg
+++ b/website/images/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" fill="#0b2239" rx="6" />
+  <text x="60" y="26" font-family="Roboto, sans-serif" font-size="20" fill="#ffffff" text-anchor="middle">Core Edge</text>
+</svg>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Core Edge</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="https://unpkg.com/feather-icons"></script>
+</head>
+<body>
+    <header>
+        <img src="images/logo.svg" alt="Core Edge logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="#features" data-i18n="nav_features">Features</a></li>
+                <li><a href="#faq" data-i18n="nav_faq">FAQ</a></li>
+                <li><a href="#contact" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="#login" data-i18n="nav_login">Login</a></li>
+            </ul>
+        </nav>
+        <select id="lang-select">
+            <option value="en">EN</option>
+            <option value="de">DE</option>
+            <option value="es">ES</option>
+        </select>
+    </header>
+
+    <section class="hero">
+        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
+        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+    </section>
+
+    <section id="features" class="features">
+        <div class="feature">
+            <i data-feather="download"></i>
+            <h3 data-i18n="feature_free_title">Free Analysis</h3>
+            <p data-i18n="feature_free_desc">Download our tool, analyze your system locally and view compliance results on your dashboard.</p>
+        </div>
+        <div class="feature">
+            <i data-feather="settings"></i>
+            <h3 data-i18n="feature_auto_title">Automated Remediation</h3>
+            <p data-i18n="feature_auto_desc">Use our AI-driven service to automatically fix custom objects and pay only for successful fixes.</p>
+        </div>
+        <div class="feature">
+            <i data-feather="globe"></i>
+            <h3 data-i18n="feature_global_title">Global & Multilingual</h3>
+            <p data-i18n="feature_global_desc">Serve your teams worldwide with localized interfaces and documentation.</p>
+        </div>
+    </section>
+
+    <section id="login" class="login">
+        <h2 data-i18n="login_title">Login</h2>
+        <form>
+            <label for="username" data-i18n="login_user">Username</label>
+            <input type="text" id="username" required>
+            <label for="password" data-i18n="login_pass">Password</label>
+            <input type="password" id="password" required>
+            <button type="submit" data-i18n="login_button">Sign In</button>
+        </form>
+        <p class="note" data-i18n="login_note">Demo login form (no backend).</p>
+    </section>
+
+    <section id="faq" class="faq">
+        <h2 data-i18n="faq_title">FAQ</h2>
+        <div class="faq-item">
+            <h4 data-i18n="faq1_q">How does the free analysis work?</h4>
+            <p data-i18n="faq1_a">Download the software, run it on your development system, and view your dashboard for results.</p>
+        </div>
+        <div class="faq-item">
+            <h4 data-i18n="faq2_q">What if I want to fix issues automatically?</h4>
+            <p data-i18n="faq2_a">Purchase a remediation plan based on the number and type of issues you want fixed.</p>
+        </div>
+        <div class="faq-item">
+            <h4 data-i18n="faq3_q">Is my data secure?</h4>
+            <p data-i18n="faq3_a">All analysis is performed locally and results are uploaded securely to your account.</p>
+        </div>
+    </section>
+
+    <section id="contact" class="contact">
+        <h2 data-i18n="contact_title">Contact Us</h2>
+        <form>
+            <label for="email" data-i18n="contact_email">Email</label>
+            <input type="email" id="email" required>
+            <label for="message" data-i18n="contact_message">Message</label>
+            <textarea id="message" rows="5" required></textarea>
+            <button type="submit" data-i18n="contact_send">Send</button>
+        </form>
+    </section>
+
+    <footer>
+        <p>&copy; <span id="year"></span> Core Edge</p>
+    </footer>
+
+    <script src="js/app.js"></script>
+    <script>feather.replace()</script>
+</body>
+</html>

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -1,0 +1,110 @@
+const translations = {
+    en: {
+        nav_features: 'Features',
+        nav_faq: 'FAQ',
+        nav_contact: 'Contact',
+        nav_login: 'Login',
+        hero_title: 'Automated Custom Object Compliance',
+        hero_subtitle: 'Prepare your SAP landscape for S/4HANA and maintain a clean core.',
+        feature_free_title: 'Free Analysis',
+        feature_free_desc: 'Download our tool, analyze your system locally and view compliance results on your dashboard.',
+        feature_auto_title: 'Automated Remediation',
+        feature_auto_desc: 'Use our AI-driven service to automatically fix custom objects and pay only for successful fixes.',
+        feature_global_title: 'Global & Multilingual',
+        feature_global_desc: 'Serve your teams worldwide with localized interfaces and documentation.',
+        login_title: 'Login',
+        login_user: 'Username',
+        login_pass: 'Password',
+        login_button: 'Sign In',
+        login_note: 'Demo login form (no backend).',
+        faq_title: 'FAQ',
+        faq1_q: 'How does the free analysis work?',
+        faq1_a: 'Download the software, run it on your development system, and view your dashboard for results.',
+        faq2_q: 'What if I want to fix issues automatically?',
+        faq2_a: 'Purchase a remediation plan based on the number and type of issues you want fixed.',
+        faq3_q: 'Is my data secure?',
+        faq3_a: 'All analysis is performed locally and results are uploaded securely to your account.',
+        contact_title: 'Contact Us',
+        contact_email: 'Email',
+        contact_message: 'Message',
+        contact_send: 'Send'
+    },
+    de: {
+        nav_features: 'Funktionen',
+        nav_faq: 'FAQ',
+        nav_contact: 'Kontakt',
+        nav_login: 'Anmeldung',
+        hero_title: 'Automatisierte Custom-Object-Compliance',
+        hero_subtitle: 'Bereiten Sie Ihre SAP-Landschaft auf S/4HANA vor und halten Sie einen sauberen Kern.',
+        feature_free_title: 'Kostenlose Analyse',
+        feature_free_desc: 'Laden Sie unser Tool herunter, analysieren Sie Ihr System lokal und sehen Sie die Ergebnisse im Dashboard.',
+        feature_auto_title: 'Automatische Behebung',
+        feature_auto_desc: 'Nutzen Sie unseren KI-Dienst, um Custom-Objekte automatisch zu korrigieren und bezahlen Sie nur für erfolgreiche Korrekturen.',
+        feature_global_title: 'Global & Mehrsprachig',
+        feature_global_desc: 'Bedienen Sie Ihre Teams weltweit mit lokalisierter Oberfläche und Dokumentation.',
+        login_title: 'Anmeldung',
+        login_user: 'Benutzername',
+        login_pass: 'Passwort',
+        login_button: 'Einloggen',
+        login_note: 'Demo-Anmeldeformular (kein Backend).',
+        faq_title: 'FAQ',
+        faq1_q: 'Wie funktioniert die kostenlose Analyse?',
+        faq1_a: 'Laden Sie die Software herunter, führen Sie sie auf Ihrem Entwicklungssystem aus und sehen Sie die Ergebnisse im Dashboard.',
+        faq2_q: 'Was, wenn ich Probleme automatisch beheben möchte?',
+        faq2_a: 'Kaufen Sie einen Behebungsplan basierend auf Anzahl und Typ der zu behobenden Probleme.',
+        faq3_q: 'Sind meine Daten sicher?',
+        faq3_a: 'Alle Analysen werden lokal ausgeführt und die Ergebnisse sicher an Ihr Konto gesendet.',
+        contact_title: 'Kontakt',
+        contact_email: 'E-Mail',
+        contact_message: 'Nachricht',
+        contact_send: 'Senden'
+    },
+    es: {
+        nav_features: 'Características',
+        nav_faq: 'Preguntas',
+        nav_contact: 'Contacto',
+        nav_login: 'Ingresar',
+        hero_title: 'Cumplimiento automatizado de objetos personalizados',
+        hero_subtitle: 'Prepare su entorno SAP para S/4HANA y mantenga un núcleo limpio.',
+        feature_free_title: 'Análisis gratuito',
+        feature_free_desc: 'Descargue nuestra herramienta, analice su sistema localmente y vea los resultados en su panel.',
+        feature_auto_title: 'Remediación automática',
+        feature_auto_desc: 'Utilice nuestro servicio impulsado por IA para corregir objetos personalizados automáticamente y pague solo por las correcciones exitosas.',
+        feature_global_title: 'Global y multilingüe',
+        feature_global_desc: 'Sirva a sus equipos en todo el mundo con interfaces y documentación localizadas.',
+        login_title: 'Ingresar',
+        login_user: 'Usuario',
+        login_pass: 'Contraseña',
+        login_button: 'Acceder',
+        login_note: 'Formulario de inicio de sesión de demostración (sin backend).',
+        faq_title: 'FAQ',
+        faq1_q: '¿Cómo funciona el análisis gratuito?',
+        faq1_a: 'Descargue el software, ejecútelo en su sistema de desarrollo y vea los resultados en su panel.',
+        faq2_q: '¿Qué pasa si quiero corregir problemas automáticamente?',
+        faq2_a: 'Compre un plan de remediación basado en la cantidad y tipo de problemas que desea corregir.',
+        faq3_q: '¿Mis datos están seguros?',
+        faq3_a: 'Todo el análisis se realiza localmente y los resultados se cargan de forma segura en su cuenta.',
+        contact_title: 'Contáctenos',
+        contact_email: 'Correo electrónico',
+        contact_message: 'Mensaje',
+        contact_send: 'Enviar'
+    }
+};
+
+function setLanguage(lang) {
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+        const key = el.getAttribute('data-i18n');
+        if (translations[lang] && translations[lang][key]) {
+            el.textContent = translations[lang][key];
+        }
+    });
+}
+
+document.getElementById('lang-select').addEventListener('change', (e) => {
+    setLanguage(e.target.value);
+});
+
+document.getElementById('year').textContent = new Date().getFullYear();
+
+// Set default language
+setLanguage('en');


### PR DESCRIPTION
## Summary
- create a `website` folder with static files for Core Edge
- implement an index page with login form, features, FAQ and contact sections
- add basic styling and multi-language support via JavaScript
- include a simple SVG logo and note use of Feather icons
- update README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_683f40bf9ed88330a50d0c8e8b99564a