### PR TITLE
Split pages for login and contact

### DIFF
--- a/website/contact.html
+++ b/website/contact.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Core Edge</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="https://unpkg.com/feather-icons"></script>
+</head>
+<body>
+    <header>
+        <img src="images/logo.svg" alt="Core Edge logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="index.html#features" data-i18n="nav_features">Features</a></li>
+                <li><a href="index.html#faq" data-i18n="nav_faq">FAQ</a></li>
+                <li><a href="contact.html" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="login.html" data-i18n="nav_login">Login</a></li>
+            </ul>
+        </nav>
+        <select id="lang-select">
+            <option value="en">EN</option>
+            <option value="de">DE</option>
+            <option value="es">ES</option>
+        </select>
+    </header>
+
+    <section class="hero">
+        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
+        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+    </section>
+
+
+    <section id="contact" class="contact">
+        <h2 data-i18n="contact_title">Contact Us</h2>
+        <form>
+            <label for="email" data-i18n="contact_email">Email</label>
+            <input type="email" id="email" required>
+            <label for="message" data-i18n="contact_message">Message</label>
+            <textarea id="message" rows="5" required></textarea>
+            <button type="submit" data-i18n="contact_send">Send</button>
+        </form>
+    </section>
+
+    <footer>
+        <p>&copy; <span id="year"></span> Core Edge</p>
+    </footer>
+
+    <script src="js/app.js"></script>
+    <script>feather.replace()</script>
+</body>
+</html>

--- a/website/css/styles.css
+++ b/website/css/styles.css
@@ -71,6 +71,12 @@ header a {
     margin: auto;
 }
 
+.feature-detail {
+    padding: 2rem;
+    max-width: 800px;
+    margin: auto;
+}
+
 .login form, .contact form {
     display: flex;
     flex-direction: column;

--- a/website/feature-automated-remediation.html
+++ b/website/feature-automated-remediation.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Core Edge</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="https://unpkg.com/feather-icons"></script>
+</head>
+<body>
+    <header>
+        <img src="images/logo.svg" alt="Core Edge logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="index.html#features" data-i18n="nav_features">Features</a></li>
+                <li><a href="index.html#faq" data-i18n="nav_faq">FAQ</a></li>
+                <li><a href="contact.html" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="login.html" data-i18n="nav_login">Login</a></li>
+            </ul>
+        </nav>
+        <select id="lang-select">
+            <option value="en">EN</option>
+            <option value="de">DE</option>
+            <option value="es">ES</option>
+        </select>
+    </header>
+
+    <section class="hero">
+        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
+        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+    </section>
+
+    <section class="feature-detail">
+        <h2>Automated Remediation</h2>
+        <p>Our AI-driven service automatically fixes custom objects and you only pay for successful corrections.</p>
+    </section>
+
+
+    <footer>
+        <p>&copy; <span id="year"></span> Core Edge</p>
+    </footer>
+
+    <script src="js/app.js"></script>
+    <script>feather.replace()</script>
+</body>
+</html>

--- a/website/feature-free-analysis.html
+++ b/website/feature-free-analysis.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Core Edge</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="https://unpkg.com/feather-icons"></script>
+</head>
+<body>
+    <header>
+        <img src="images/logo.svg" alt="Core Edge logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="index.html#features" data-i18n="nav_features">Features</a></li>
+                <li><a href="index.html#faq" data-i18n="nav_faq">FAQ</a></li>
+                <li><a href="contact.html" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="login.html" data-i18n="nav_login">Login</a></li>
+            </ul>
+        </nav>
+        <select id="lang-select">
+            <option value="en">EN</option>
+            <option value="de">DE</option>
+            <option value="es">ES</option>
+        </select>
+    </header>
+
+    <section class="hero">
+        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
+        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+    </section>
+
+    <section class="feature-detail">
+        <h2>Free Analysis</h2>
+        <p>Download our tool, run it locally on your development system and view the compliance results in your dashboard.</p>
+    </section>
+
+
+    <footer>
+        <p>&copy; <span id="year"></span> Core Edge</p>
+    </footer>
+
+    <script src="js/app.js"></script>
+    <script>feather.replace()</script>
+</body>
+</html>

--- a/website/feature-global-multilingual.html
+++ b/website/feature-global-multilingual.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Core Edge</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="https://unpkg.com/feather-icons"></script>
+</head>
+<body>
+    <header>
+        <img src="images/logo.svg" alt="Core Edge logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="index.html#features" data-i18n="nav_features">Features</a></li>
+                <li><a href="index.html#faq" data-i18n="nav_faq">FAQ</a></li>
+                <li><a href="contact.html" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="login.html" data-i18n="nav_login">Login</a></li>
+            </ul>
+        </nav>
+        <select id="lang-select">
+            <option value="en">EN</option>
+            <option value="de">DE</option>
+            <option value="es">ES</option>
+        </select>
+    </header>
+
+    <section class="hero">
+        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
+        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+    </section>
+
+    <section class="feature-detail">
+        <h2>Global &amp; Multilingual</h2>
+        <p>Serve your teams worldwide with localized interfaces and documentation to support every region.</p>
+    </section>
+
+
+    <footer>
+        <p>&copy; <span id="year"></span> Core Edge</p>
+    </footer>
+
+    <script src="js/app.js"></script>
+    <script>feather.replace()</script>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -15,8 +15,8 @@
             <ul>
                 <li><a href="#features" data-i18n="nav_features">Features</a></li>
                 <li><a href="#faq" data-i18n="nav_faq">FAQ</a></li>
-                <li><a href="#contact" data-i18n="nav_contact">Contact</a></li>
-                <li><a href="#login" data-i18n="nav_login">Login</a></li>
+                <li><a href="contact.html" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="login.html" data-i18n="nav_login">Login</a></li>
             </ul>
         </nav>
         <select id="lang-select">
@@ -32,34 +32,23 @@
     </section>
 
     <section id="features" class="features">
-        <div class="feature">
+        <a href="feature-free-analysis.html" class="feature">
             <i data-feather="download"></i>
             <h3 data-i18n="feature_free_title">Free Analysis</h3>
             <p data-i18n="feature_free_desc">Download our tool, analyze your system locally and view compliance results on your dashboard.</p>
-        </div>
-        <div class="feature">
+        </a>
+        <a href="feature-automated-remediation.html" class="feature">
             <i data-feather="settings"></i>
             <h3 data-i18n="feature_auto_title">Automated Remediation</h3>
             <p data-i18n="feature_auto_desc">Use our AI-driven service to automatically fix custom objects and pay only for successful fixes.</p>
-        </div>
-        <div class="feature">
+        </a>
+        <a href="feature-global-multilingual.html" class="feature">
             <i data-feather="globe"></i>
             <h3 data-i18n="feature_global_title">Global & Multilingual</h3>
             <p data-i18n="feature_global_desc">Serve your teams worldwide with localized interfaces and documentation.</p>
-        </div>
+        </a>
     </section>
 
-    <section id="login" class="login">
-        <h2 data-i18n="login_title">Login</h2>
-        <form>
-            <label for="username" data-i18n="login_user">Username</label>
-            <input type="text" id="username" required>
-            <label for="password" data-i18n="login_pass">Password</label>
-            <input type="password" id="password" required>
-            <button type="submit" data-i18n="login_button">Sign In</button>
-        </form>
-        <p class="note" data-i18n="login_note">Demo login form (no backend).</p>
-    </section>
 
     <section id="faq" class="faq">
         <h2 data-i18n="faq_title">FAQ</h2>
@@ -77,16 +66,6 @@
         </div>
     </section>
 
-    <section id="contact" class="contact">
-        <h2 data-i18n="contact_title">Contact Us</h2>
-        <form>
-            <label for="email" data-i18n="contact_email">Email</label>
-            <input type="email" id="email" required>
-            <label for="message" data-i18n="contact_message">Message</label>
-            <textarea id="message" rows="5" required></textarea>
-            <button type="submit" data-i18n="contact_send">Send</button>
-        </form>
-    </section>
 
     <footer>
         <p>&copy; <span id="year"></span> Core Edge</p>

--- a/website/login.html
+++ b/website/login.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Core Edge</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/styles.css">
+    <script src="https://unpkg.com/feather-icons"></script>
+</head>
+<body>
+    <header>
+        <img src="images/logo.svg" alt="Core Edge logo" class="logo">
+        <nav>
+            <ul>
+                <li><a href="index.html#features" data-i18n="nav_features">Features</a></li>
+                <li><a href="index.html#faq" data-i18n="nav_faq">FAQ</a></li>
+                <li><a href="contact.html" data-i18n="nav_contact">Contact</a></li>
+                <li><a href="login.html" data-i18n="nav_login">Login</a></li>
+            </ul>
+        </nav>
+        <select id="lang-select">
+            <option value="en">EN</option>
+            <option value="de">DE</option>
+            <option value="es">ES</option>
+        </select>
+    </header>
+
+    <section class="hero">
+        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
+        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+    </section>
+
+
+    <section id="login" class="login">
+        <h2 data-i18n="login_title">Login</h2>
+        <form>
+            <label for="username" data-i18n="login_user">Username</label>
+            <input type="text" id="username" required>
+            <label for="password" data-i18n="login_pass">Password</label>
+            <input type="password" id="password" required>
+            <button type="submit" data-i18n="login_button">Sign In</button>
+        </form>
+        <p class="note" data-i18n="login_note">Demo login form (no backend).</p>
+    </section>
+
+
+
+    <footer>
+        <p>&copy; <span id="year"></span> Core Edge</p>
+    </footer>
+
+    <script src="js/app.js"></script>
+    <script>feather.replace()</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create standalone login and contact pages
- link feature summaries to their own detail pages
- add styles for feature details
- remove login and contact sections from the landing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f47d808e88330a3cc4b5d29b36333