### PR TITLE
Add dashboard and bypass login

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -7,6 +7,7 @@ The site provides:
 
 - Overview of free system analysis and paid remediation.
 - Login area (front-end only) and multilingual support (English, German, Spanish).
+- Demo dashboard with placeholder metrics accessible after login.
 - FAQ and contact form.
 
 Open-source Feather icons are used under the MIT license.

--- a/website/dashboard.html
+++ b/website/dashboard.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css">
     <script src="https://unpkg.com/feather-icons"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <header>
@@ -27,30 +28,39 @@
     </header>
 
     <section class="hero">
-        <h1 data-i18n="hero_title">Automated Custom Object Compliance</h1>
-        <p data-i18n="hero_subtitle">Prepare your SAP landscape for S/4HANA and maintain a clean core.</p>
+        <h1>Dashboard</h1>
+        <p>Overview of your system analysis.</p>
     </section>
 
-
-    <section id="login" class="login">
-        <h2 data-i18n="login_title">Login</h2>
-        <form action="dashboard.html">
-            <label for="username" data-i18n="login_user">Username</label>
-            <input type="text" id="username">
-            <label for="password" data-i18n="login_pass">Password</label>
-            <input type="password" id="password">
-            <button type="submit" data-i18n="login_button">Sign In</button>
-        </form>
-        <p class="note" data-i18n="login_note">Demo login form (no backend).</p>
+    <section class="feature-detail">
+        <canvas id="metricsChart" width="400" height="200"></canvas>
     </section>
-
-
 
     <footer>
         <p>&copy; <span id="year"></span> Core Edge</p>
     </footer>
 
     <script src="js/app.js"></script>
-    <script>feather.replace()</script>
+    <script>
+        const ctx = document.getElementById('metricsChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: ['Objects', 'S/4 Issues', 'Core Issues', 'Auto %'],
+                datasets: [{
+                    label: 'Metrics',
+                    data: [120, 25, 80, 60],
+                    backgroundColor: ['#2980b9', '#6dd5fa', '#2980b9', '#6dd5fa']
+                }]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: { beginAtZero: true }
+                }
+            }
+        });
+        feather.replace();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make demo dashboard page with bar chart metrics
- bypass credential checks on login
- document dashboard in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f4d3a4f4083308b192dfaf5f50cff